### PR TITLE
Add MySQL schema and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,21 @@ During development you can use watch mode:
 ```bash
 npm run test:watch
 ```
+
+## Database Setup
+
+The `init/` directory contains SQL scripts for PostgreSQL and MySQL.
+
+### PostgreSQL
+
+```bash
+psql -f init/tables.sql
+psql -f init/functions.sql
+```
+
+### MySQL
+
+```bash
+mysql -u <user> -p <database> < init/mysql_tables.sql
+mysql -u <user> -p <database> < init/mysql_functions.sql
+```

--- a/init/mysql_functions.sql
+++ b/init/mysql_functions.sql
@@ -1,0 +1,17 @@
+DELIMITER $$
+
+CREATE PROCEDURE get_random_design()
+BEGIN
+  SELECT * FROM designs
+  ORDER BY RAND()
+  LIMIT 1;
+END $$
+
+CREATE PROCEDURE get_random_designs()
+BEGIN
+  SELECT * FROM designs
+  ORDER BY RAND()
+  LIMIT 3;
+END $$
+
+DELIMITER ;

--- a/init/mysql_tables.sql
+++ b/init/mysql_tables.sql
@@ -1,0 +1,28 @@
+CREATE TABLE studio (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `key` VARCHAR(255),
+  value TEXT,
+  createdat TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE designs (
+  id CHAR(36) NOT NULL DEFAULT (UUID()),
+  `externalId` BIGINT NOT NULL,
+  title VARCHAR(255) NOT NULL DEFAULT '85',
+  description TEXT NOT NULL,
+  keywords TEXT NOT NULL,
+  `imageName` VARCHAR(255),
+  `externalImageUrl` TEXT,
+  `externalLink` TEXT,
+  category VARCHAR(255) DEFAULT 'no_category',
+  collection VARCHAR(255) DEFAULT 'no_collection',
+  `backgroundColor` VARCHAR(255) NOT NULL DEFAULT '#FFFFFF',
+  `backgroundColors` TEXT,
+  shared BOOLEAN DEFAULT FALSE,
+  props JSON,
+  `createdAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updatedAt` TIMESTAMP NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY designs_externalid_key(`externalId`),
+  UNIQUE KEY designs_title_key(title)
+);


### PR DESCRIPTION
## Summary
- add MySQL schema and functions
- document how to apply initialization scripts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c868f36fc83308d07d5b59a6dbb63