### PR TITLE
Fix slug generation whitespace handling

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -20,10 +20,16 @@ export function truncateText(text: string, maxLength: number): string {
 }
 
 export function generateSlug(text: string): string {
-  return text
+  const hasLeadingSpace = /^\s/.test(text);
+  const hasTrailingSpace = /\s$/.test(text);
+
+  const slug = text
+    .trim()
     .toLowerCase()
-    .replace(/[^\w ]+/g, "")
-    .replace(/ +/g, "-");
+    .replace(/[^\w\s]+/g, '')
+    .replace(/\s+/g, '-');
+
+  return `${hasLeadingSpace ? '-' : ''}${slug}${hasTrailingSpace ? '-' : ''}`;
 }
 
 export function calculateReadingTime(text: string): number {


### PR DESCRIPTION
## Summary
- trim input text and consolidate spaces before slug generation
- ensure leading or trailing whitespace still converts to hyphens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e0a1007d883308adc3098af87f849