### PR TITLE
Remove default '85' from SQL tables

### DIFF
--- a/init/mysql_tables.sql
+++ b/init/mysql_tables.sql
@@ -8,7 +8,7 @@ CREATE TABLE studio (
 CREATE TABLE designs (
   id CHAR(36) NOT NULL DEFAULT (UUID()),
   `externalId` BIGINT NOT NULL,
-  title VARCHAR(255) NOT NULL DEFAULT '85',
+  title VARCHAR(255) NOT NULL,
   description TEXT NOT NULL,
   keywords TEXT NOT NULL,
   `imageName` VARCHAR(255),

--- a/init/tables.sql
+++ b/init/tables.sql
@@ -11,7 +11,7 @@ create table
     public.designs (
                        id uuid not null default gen_random_uuid (),
                        "externalId" bigint not null,
-                       title character varying not null default '85'::character varying,
+                       title character varying not null,
                        description text not null,
                        keywords text not null,
                        "imageName" character varying null,


### PR DESCRIPTION
## Summary
- adjust `title` column definitions

## Testing
- `npm test` *(fails: ERR_REQUIRE_ESM)*

------
https://chatgpt.com/codex/tasks/task_e_687e0b5624a48330aa7cf70850805f34